### PR TITLE
ENH: allow to unmask multiple "volumes" in one call

### DIFF
--- a/neurosynth/base/mask.py
+++ b/neurosynth/base/mask.py
@@ -35,9 +35,21 @@ class Mask(object):
 
   def unmask(self, data):
     """ Reconstruct a masked vector into the original 3D volume. """
-    img = self.full.copy()
-    img[self.in_mask] = data
-    return np.reshape(img, self.volume.shape)
+    n_in_mask_voxels = len(self.in_mask[0])
+    if data.ndim == 2:
+      n_volumes = data.shape[1]
+      # we got two dimensions, so take 2nd dimension as the temporal dimension
+      assert(len(data) == n_in_mask_voxels)
+      assert(self.full.ndim == 1)
+      # but we generate x,y,z,t volume
+      img = np.zeros(self.full.shape + (n_volumes,))
+      #for t in xrange(n_volumes):
+      img[self.in_mask, :] = data
+      return np.reshape(img, self.volume.shape + (n_volumes,))
+    else:
+      img = self.full.copy()
+      img[self.in_mask] = data
+      return np.reshape(img, self.volume.shape)
 
   def get_header(self):
     """ A wrapper for the NiBabel method. """

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -70,6 +70,31 @@ class TestBase(unittest.TestCase):
     self.assertEquals(len(ids), 1)
     self.assertEquals('study5', ids[0])
 
+  def test_unmask(self):
+    """ Test unmasking on 1d and 2d vectors (going back to 3d and 4d)
+
+    TODO: test directly on Mask class and its functions, and on
+    some smaller example data.  But then it should get into a separate
+    TestCase to not 'reload' the same Dataset.
+    So for now let's just reuse loaded Dataset and provide
+    rudimentary testing
+    """
+    dataset = self.dataset
+    ids = dataset.get_ids_by_mask(
+        get_test_data_path() + 'sgacc_mask.nii.gz')
+    nvoxels = dataset.volume.in_mask[0].shape[0]
+
+    nvols = 2
+    data2d = np.arange(nvoxels*nvols).reshape((nvoxels, -1))
+
+    data2d_unmasked_separately = [
+      dataset.volume.unmask(data2d[:, i]) for i in xrange(nvols)]
+    data2d_unmasked = dataset.volume.unmask(data2d)
+    self.assertEqual(data2d_unmasked.shape,
+                     data2d_unmasked_separately[0].shape + (nvols,))
+    # and check corresponding volumes
+    for i in xrange(nvols):
+      self.assertTrue(np.all(data2d_unmasked[..., i] == data2d_unmasked_separately[i]))
   def test_selection_by_peaks(self):
     """ Test peak-based Mappable selection. """
     ids = self.dataset.get_ids_by_peaks(np.array([[3, 30, -9]]))


### PR DESCRIPTION
logically multiple samples should have gone into rows, but to mimiq
nibabel order (x,y,z,t) with t in the last dimension and stay coherent
with order of dimensions as returned by analyze_features -- multiple
volumes are assumed to reside in colums
