### PR TITLE
added get_features_by_ids

### DIFF
--- a/neurosynth/base/dataset.py
+++ b/neurosynth/base/dataset.py
@@ -246,6 +246,7 @@ class Dataset(object):
         indices = np.where(prop_mask_active > threshold)[0]
         return self.get_image_data(indices) if get_image_data else [self.image_table.ids[ind] for ind in indices]
 
+
     def get_ids_by_peaks(self, peaks, r=10, threshold=0.0, get_image_data=False):
         """ A wrapper for get_ids_by_mask. Takes a set of xyz coordinates and generates
         a new Nifti1Image to use as a mask.
@@ -578,3 +579,15 @@ class FeatureTable(object):
             lexer, self.dataset, threshold=threshold, func='sum')
         parser.build()
         return parser.parse(expression).keys()
+
+    def get_features_by_ids(self, ids=None, threshold=0.0001, func='sum', get_weights=False):
+        ''' Returns features that mach to ids'''
+        id_indices = np.in1d(self.ids, ids)
+        data = self.data.toarray()
+        ids_weights = reduce(lambda x,y: x+y, data[id_indices,:])/len(id_indices)
+        above_thresh = (ids_weights >= threshold)
+        features_to_keep = np.array(self.feature_names)[np.where(above_thresh)]
+        if get_weights:
+            return dict(zip(features_to_keep, list(ids_weights[above_thresh])))
+        else:
+            return features_to_keep


### PR DESCRIPTION
Hi Neurosynth,

I'd like to add a way to extract features, given a set of id's. An example use case: I have a Nifti-file mask, then get_ids_by_mask, and then get_features_by_ids.

This is helpful when I have a brain region and I would like to see the functions associated with it.

I would have tried to go directly from mask to features, but separating the features_table from the image_table seemed important since the length of the id-list is inconsistent between them.

Thanks,
