### PR TITLE
Fix errors in add_mappables and delete_mappables.

### DIFF
--- a/neurosynth/base/dataset.py
+++ b/neurosynth/base/dataset.py
@@ -213,7 +213,7 @@ class Dataset(object):
         elif mappables != None:
             self.mappables.extend(mappables)
         if remap:
-            self.image_table = self.create_image_table()
+            self.create_image_table()
 
     def delete_mappables(self, ids, remap=True):
         """ Delete specific Mappables from the Dataset.
@@ -226,9 +226,9 @@ class Dataset(object):
             remap (bool): Optional flag indicating whether to regenerate the
                 entire ImageTable after deleting undesired Mappables.
         """
-        self.mappables = [m for m in self.mappables if m not in ids]
+        self.mappables = [m for m in self.mappables if m.id not in ids]
         if remap:
-            self.image_table = self.create_image_table()
+            self.create_image_table()
 
     def get_studies(self, features=None, expression=None, mask=None,
                     peaks=None, frequency_threshold=0.001,

--- a/neurosynth/tests/test_base.py
+++ b/neurosynth/tests/test_base.py
@@ -70,6 +70,17 @@ class TestBase(unittest.TestCase):
             ['study3', 'study4', 'study5'], get_image_data=True)
         self.assertEqual(mappables.shape, (228453, 3))
 
+    def test_delete_mappables(self):
+        orig_ids = [m.id for m in self.dataset.mappables]
+        
+        # Remove first ten studies
+        rm_ids = orig_ids[:10]
+        keep_ids = list(set(orig_ids) - set(rm_ids))
+        self.dataset.delete_mappables(rm_ids)
+        new_ids = [m.id for m in self.dataset.mappables]
+        
+        self.assertEqual(keep_ids, new_ids)
+
     def test_image_table_loads(self):
         """ Test ImageTable initialization. """
         self.assertIsNotNone(self.dataset.image_table)


### PR DESCRIPTION
I made a couple of changes to Dataset class methods:
- delete_mappables was checking mappables against ids instead of mappable ids against ids
- both functions assigned output from create_image_table to class, but create_image_table assigns image_table in-place