### PR TITLE
Ensure download_abstracts Py3 compatibility.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ neurosynth.egg-info
 neurosynth/base/lextab.py
 neurosynth/base/parser.out
 neurosynth/base/parsetab.py
-neurosynth/resources/mallet-2.0.7
+neurosynth/resources/mallet*
+neurosynth/resources/topic_models

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -36,7 +36,7 @@ print_conda_requirements() {
     #   - for scikit-learn, SCIKIT_LEARN_VERSION is used
     TO_INSTALL_ALWAYS="pip nose six"
     REQUIREMENTS="$TO_INSTALL_ALWAYS"
-    TO_INSTALL_MAYBE="python numpy scipy matplotlib scikit-learn ply pandas"
+    TO_INSTALL_MAYBE="python numpy scipy matplotlib scikit-learn ply pandas biopython future"
     for PACKAGE in $TO_INSTALL_MAYBE; do
         # Capitalize package name and add _VERSION
         PACKAGE_VERSION_VARNAME="${PACKAGE^^}_VERSION"

--- a/neurosynth/analysis/stats.py
+++ b/neurosynth/analysis/stats.py
@@ -3,7 +3,6 @@
 import warnings
 import numpy as np
 from scipy import special
-from scipy.stats import ss
 
 
 def pearson(x, y):
@@ -11,7 +10,7 @@ def pearson(x, y):
     data = np.vstack((x, y))
     ms = data.mean(axis=1)[(slice(None, None, None), None)]
     datam = data - ms
-    datass = np.sqrt(ss(datam, axis=1))
+    datass = np.sqrt(np.sum(datam ** 2, axis=1))
     temp = np.dot(datam[1:], datam[0].T)
     rs = temp / (datass[1:] * datass[0])
     return rs

--- a/neurosynth/base/dataset.py
+++ b/neurosynth/base/dataset.py
@@ -4,6 +4,8 @@ import logging
 import re
 import os
 import sys
+
+from builtins import range
 import numpy as np
 import pandas as pd
 from scipy import sparse
@@ -90,7 +92,7 @@ def download_abstracts(dataset, path='.', email=None, out_file=None):
 
     records = []
     # PubMed only allows you to search ~1000 at a time. I chose 900 to be safe.
-    chunks = [pmids[x:x+900] for x in xrange(0, len(pmids), 900)]
+    chunks = [pmids[x:x+900] for x in range(0, len(pmids), 900)]
     for chunk in chunks:
         h = Entrez.efetch(db='pubmed', id=chunk, rettype='medline',
                           retmode='text')

--- a/neurosynth/base/imageutils.py
+++ b/neurosynth/base/imageutils.py
@@ -15,7 +15,7 @@ def get_sphere(coords, r=4, vox_dims=(2, 2, 2), dims=(91, 109, 91)):
     and then discards all points outside sphere. Only returns values that
     fall within the dimensions of the image."""
     r = float(r)
-    xx, yy, zz = [slice(-r / vox_dims[i], r / vox_dims[
+    xx, yy, zz = [slice(-r // vox_dims[i], r // vox_dims[
                         i] + 0.01, 1) for i in range(len(coords))]
     cube = np.vstack([row.ravel() for row in np.mgrid[xx, yy, zz]])
     sphere = cube[:, np.sum(np.dot(np.diag(

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ ply
 scikit-learn
 six
 biopython
+future


### PR DESCRIPTION
`download_abstracts` used to use `xrange`, which caused problems for Python 3 users. With these changes, it works fine.