### PR TITLE
Removed the use of deprecated scipy.stats.ss function

### DIFF
--- a/neurosynth/analysis/stats.py
+++ b/neurosynth/analysis/stats.py
@@ -3,7 +3,6 @@
 import warnings
 import numpy as np
 from scipy import special
-from scipy.stats import ss
 
 
 def pearson(x, y):
@@ -11,7 +10,7 @@ def pearson(x, y):
     data = np.vstack((x, y))
     ms = data.mean(axis=1)[(slice(None, None, None), None)]
     datam = data - ms
-    datass = np.sqrt(ss(datam, axis=1))
+    datass = np.sqrt(np.sum(datam**2, axis=1))
     temp = np.dot(datam[1:], datam[0].T)
     rs = temp / (datass[1:] * datass[0])
     return rs


### PR DESCRIPTION
I recently updated scipy to version 1.0.0 and found that scipy.stats.ss used in the analysis/stats.py module has been deprecated.