### PR TITLE
Fixed stats.fdr bug to handle edge of single passing test

### DIFF
--- a/neurosynth/analysis/stats.py
+++ b/neurosynth/analysis/stats.py
@@ -66,4 +66,4 @@ def fdr(p, q=.05):
     nvox = p.shape[0]
     null = np.array(range(1, nvox + 1), dtype='float') * q / nvox
     below = np.where(s <= null)[0]
-    return s[max(below)] if any(below) else -1
+    return s[max(below)] if len(below) else -1

--- a/neurosynth/tests/test_analysis.py
+++ b/neurosynth/tests/test_analysis.py
@@ -124,6 +124,11 @@ class TestAnalysis(unittest.TestCase):
         self.assertEqual(n_unique, 4)
         shutil.rmtree(d)
 
+    def test_fdr(self):
+        pvals = np.array([.005, .1, .2, .5])
+        fdr_p = stats.fdr(pvals)
+        self.assertEqual(fdr_p, pvals[0])
+
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestAnalysis)
 


### PR DESCRIPTION
hey @tyarkoni since we're using your fdr correction code over in [nltools](https://github.com/cosanlab/nltools) I noticed this edge-case bug that looks like it exists in the neurosynth code-base as well. Here's a PR fix and a link to the brief description: 

https://github.com/cosanlab/nltools/issues/262