### PR TITLE
replace sklearn's deprecated RandomizedPCA with PCA

### DIFF
--- a/neurosynth/analysis/cluster.py
+++ b/neurosynth/analysis/cluster.py
@@ -158,13 +158,22 @@ def magic(dataset, method='coactivation', roi_mask=None,
         reference = roi
 
     if reduce_reference is not None:
+
+        # For non-coactivation-based approaches, transpose the data matrix
+        transpose = (method == 'coactivation')
+
         if isinstance(reduce_reference, string_types):
+
+            # Number of components can't exceed feature count or cluster count
+            n_feat = len(reference.data.T if transpose else reference.data)
+            n_components = min(n_components, n_feat)
+            if n_clusters is not None:
+                n_components = min(n_components, n_clusters)
+
             reduce_reference = {
-                'pca': sk_decomp.RandomizedPCA,
+                'pca': sk_decomp.PCA,
                 'ica': sk_decomp.FastICA
             }[reduce_reference](n_components)
-
-        transpose = (method == 'coactivation')
         reference = reference.transform(reduce_reference, transpose=transpose)
 
     if method == 'coactivation':

--- a/neurosynth/analysis/cluster.py
+++ b/neurosynth/analysis/cluster.py
@@ -85,6 +85,9 @@ def magic(dataset, method='coactivation', roi_mask=None,
             'studies': Treat each study as a feature in an n-dimensional space.
                 I.e., voxels will be assigned to the same cluster if they tend
                 to be co-reported in similar studies.
+            'features': Voxels will be assigned to the same cluster if they
+                tend to have similar feature vectors (i.e., the studies that
+                activate those voxels tend to use similar terms).
         roi_mask: A string, nibabel image, or numpy array providing an
             inclusion mask of voxels to cluster. If None, the default mask
             in the Dataset instance is used (typically, all in-brain voxels).
@@ -159,21 +162,19 @@ def magic(dataset, method='coactivation', roi_mask=None,
 
     if reduce_reference is not None:
 
-        # For non-coactivation-based approaches, transpose the data matrix
-        transpose = (method == 'coactivation')
-
         if isinstance(reduce_reference, string_types):
 
             # Number of components can't exceed feature count or cluster count
-            n_feat = len(reference.data.T if transpose else reference.data)
+            n_feat = reference.data.shape[1]
             n_components = min(n_components, n_feat)
-            if n_clusters is not None:
-                n_components = min(n_components, n_clusters)
 
             reduce_reference = {
                 'pca': sk_decomp.PCA,
                 'ica': sk_decomp.FastICA
             }[reduce_reference](n_components)
+
+        # For non-coactivation-based approaches, transpose the data matrix
+        transpose = (method == 'coactivation')
         reference = reference.transform(reduce_reference, transpose=transpose)
 
     if method == 'coactivation':
@@ -190,7 +191,6 @@ def magic(dataset, method='coactivation', roi_mask=None,
         }[clustering_algorithm](n_clusters, **clustering_kwargs)
 
     labels = clustering_algorithm.fit_predict(distances) + 1.
-
     header = roi.masker.get_header()
     header['cal_max'] = labels.max()
     header['cal_min'] = labels.min()


### PR DESCRIPTION
Replaces `RandomizedPCA` with `PCA`—the former has been removed in sklearn. There's now no need to explicitly set the solver to randomized, as `svd_solver="auto"` by default, which automatically opts for the randomized solver if dimensionality is high.

Also adds checks to make sure the number of requested components doesn't exceed the max available.