### PR TITLE
Updates because of Pandas deprecations

### DIFF
--- a/neurosynth/base/dataset.py
+++ b/neurosynth/base/dataset.py
@@ -776,6 +776,11 @@ class FeatureTable(object):
 
     def _csr_to_sdf(self):
         """ Inverse of _sdf_to_csr(). """
-        self.data = pd.DataFrame(self.data['values'].todense(),
-                                 index=self.data['index'],
-                                 columns=self.data['columns']).sparse.to_sparse()
+        if ~self.data.dtypes.apply(pd.api.types.is_sparse).all():
+            self.data = pd.DataFrame(self.data['values'].todense(),
+                                     index=self.data['index'],
+                                     columns=self.data['columns']).sparse.to_sparse()
+        else:
+            self.data = pd.DataFrame(self.data['values'].todense(),
+                                     index=self.data['index'],
+                                     columns=self.data['columns'])

--- a/neurosynth/base/dataset.py
+++ b/neurosynth/base/dataset.py
@@ -631,7 +631,9 @@ class FeatureTable(object):
 
         data = old_data.merge(
             features, how=merge, left_index=True, right_index=True)
-        self.data = data.fillna(0.0).sparse.to_sparse()
+        self.data = data.fillna(0.0)
+        if self.data.dtypes.apply(pd.api.types.is_sparse).all():
+            self.data = sparse.to_sparse()
 
     @property
     def feature_names(self):

--- a/neurosynth/base/dataset.py
+++ b/neurosynth/base/dataset.py
@@ -621,7 +621,11 @@ class FeatureTable(object):
                 "instance from a newer database file that uses PMIDs rather "
                 "than doi's as the study identifiers in the first column.")
 
-        old_data = self.data.sparse.to_dense()
+        old_data = self.data
+        
+        if self.data.dtypes.apply(pd.api.types.is_sparse).all():
+            old_data = self.data.sparse.to_dense()
+        
         # Handle features with duplicate names
         common_features = list(set(old_data.columns) & set(features.columns))
         if duplicates == 'ignore':
@@ -759,7 +763,11 @@ class FeatureTable(object):
 
     def _sdf_to_csr(self):
         """ Convert FeatureTable to SciPy CSR matrix. """
-        data = self.data.sparse.to_dense()
+        data = self.data
+        
+        if data.dtypes.apply(pd.api.types.is_sparse).all():
+            data.sparse.to_dense()
+            
         self.data = {
             'columns': list(data.columns),
             'index': list(data.index),

--- a/neurosynth/base/dataset.py
+++ b/neurosynth/base/dataset.py
@@ -631,7 +631,7 @@ class FeatureTable(object):
 
         data = old_data.merge(
             features, how=merge, left_index=True, right_index=True)
-        self.data = data.fillna(0.0).to_sparse()
+        self.data = data.fillna(0.0).sparse.to_sparse()
 
     @property
     def feature_names(self):
@@ -768,4 +768,4 @@ class FeatureTable(object):
         """ Inverse of _sdf_to_csr(). """
         self.data = pd.DataFrame(self.data['values'].todense(),
                                  index=self.data['index'],
-                                 columns=self.data['columns']).to_sparse()
+                                 columns=self.data['columns']).sparse.to_sparse()

--- a/neurosynth/base/dataset.py
+++ b/neurosynth/base/dataset.py
@@ -663,10 +663,10 @@ class FeatureTable(object):
         result = self.data
 
         if ids is not None:
-            result = result.ix[ids]
+            result = result.loc[ids]
 
         if features is not None:
-            result = result.ix[:, features]
+            result = result.loc[:, features]
 
         return result.sparse.to_dense() if dense else result
 
@@ -719,7 +719,7 @@ class FeatureTable(object):
         if isinstance(features, str):
             features = [features]
         features = self.search_features(features)  # Expand wild cards
-        feature_weights = self.data.ix[:, features]
+        feature_weights = self.data.loc[:, features]
         weights = feature_weights.apply(func, 1)
         above_thresh = weights[weights >= threshold]
         # ids_to_keep = self.ids[above_thresh]
@@ -757,7 +757,7 @@ class FeatureTable(object):
                             get_weights=False):
         ''' Returns features for which the mean loading across all specified
         studies (in ids) is >= threshold. '''
-        weights = self.data.ix[ids].apply(func, 0)
+        weights = self.data.loc[ids].apply(func, 0)
         above_thresh = weights[weights >= threshold]
         return above_thresh if get_weights else list(above_thresh.index)
 

--- a/neurosynth/base/dataset.py
+++ b/neurosynth/base/dataset.py
@@ -621,7 +621,7 @@ class FeatureTable(object):
                 "instance from a newer database file that uses PMIDs rather "
                 "than doi's as the study identifiers in the first column.")
 
-        old_data = self.data.to_dense()
+        old_data = self.data.sparse.to_dense()
         # Handle features with duplicate names
         common_features = list(set(old_data.columns) & set(features.columns))
         if duplicates == 'ignore':
@@ -662,7 +662,7 @@ class FeatureTable(object):
         if features is not None:
             result = result.ix[:, features]
 
-        return result.to_dense() if dense else result
+        return result.sparse.to_dense() if dense else result
 
     def get_ordered_names(self, features):
         """ Given a list of features, returns features in order that they
@@ -757,7 +757,7 @@ class FeatureTable(object):
 
     def _sdf_to_csr(self):
         """ Convert FeatureTable to SciPy CSR matrix. """
-        data = self.data.to_dense()
+        data = self.data.sparse.to_dense()
         self.data = {
             'columns': list(data.columns),
             'index': list(data.index),


### PR DESCRIPTION
`to_dense()` and `ix()` have been deprecated; these changes update to `np.asarray()` and `.loc` and fix additional resulting issues with making dense matrices