### PR TITLE
[FIX] Decoding with mask

### DIFF
--- a/neurosynth/analysis/decode.py
+++ b/neurosynth/analysis/decode.py
@@ -169,10 +169,6 @@ class Decoder:
         self.feature_images = meta.analyze_features(
             self.dataset, self.feature_names, image_type=image_type,
             threshold=threshold)
-        # Apply a mask if one was originally passed
-        if self.masker.layers:
-            in_mask = self.masker.get_mask(in_global_mask=True)
-            self.feature_images = self.feature_images[in_mask, :]
 
     def _load_features_from_images(self, images, names=None):
         """ Load feature image data from image files.

--- a/neurosynth/analysis/meta.py
+++ b/neurosynth/analysis/meta.py
@@ -46,8 +46,11 @@ def analyze_features(dataset, features=None, image_type='association-test_z',
         ma = MetaAnalysis(dataset, ids, q=q)
 
         if output_dir is None:
-            in_mask = dataset.masker.get_mask(in_global_mask=True)
-            result[:, i] = ma.images[image_type][in_mask]
+            if dataset.masker.layers:
+                in_mask = dataset.masker.get_mask(in_global_mask=True)
+                result[:, i] = ma.images[image_type][in_mask]
+            else:
+                result[:, i] = ma.images[image_type]
         else:
             pfx = f if prefix is None else prefix + '_' + f
             ma.save_results(output_dir=output_dir, prefix=pfx)

--- a/neurosynth/analysis/meta.py
+++ b/neurosynth/analysis/meta.py
@@ -44,8 +44,10 @@ def analyze_features(dataset, features=None, image_type='association-test_z',
     for i, f in enumerate(features):
         ids = dataset.get_studies(features=f, frequency_threshold=threshold)
         ma = MetaAnalysis(dataset, ids, q=q)
+
         if output_dir is None:
-            result[:, i] = ma.images[image_type]
+            in_mask = dataset.masker.get_mask(in_global_mask=True)
+            result[:, i] = ma.images[image_type][in_mask]
         else:
             pfx = f if prefix is None else prefix + '_' + f
             ma.save_results(output_dir=output_dir, prefix=pfx)


### PR DESCRIPTION
This PR resolves #90. In short, decoding with the mask parameter results in an error because an attempt is made to assign the MetaAnalysis unmasked output to an array with length equal to the number of voxels in the mask.

The error can be produced as follows: 
```python
from neurosynth.base.dataset import Dataset
from neurosynth.analysis import decode
from nilearn import datasets

mni152 = datasets.load_mni152_template()
mask = mni152.get_fdata() > 5000 #nonsense mask

dataset = Dataset(dataset_pkl)
decoder = decode.Decoder(dataset, features=['emotion', 'pain', 'somatosensory', 'wm', 'inhibition'], mask=mask)
```

which results in the following traceback
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Applications/miniconda2/envs/academic/lib/python3.7/site-packages/neurosynth/analysis/decode.py", line 62, in __init__
    threshold=threshold)
  File "/Applications/miniconda2/envs/academic/lib/python3.7/site-packages/neurosynth/analysis/decode.py", line 152, in load_features
    features, image_type=image_type, threshold=threshold)
  File "/Applications/miniconda2/envs/academic/lib/python3.7/site-packages/neurosynth/analysis/decode.py", line 171, in _load_features_from_dataset
    threshold=threshold)
  File "/Applications/miniconda2/envs/academic/lib/python3.7/site-packages/neurosynth/analysis/meta.py", line 48, in analyze_features
    result[:, i] = ma.images[image_type]
ValueError: could not broadcast input array from shape (228453) into shape (184916)
```

This issue is resolved in this PR by removing the masking functionality in `neurosynth.analysis.decode._load_features_from_dataset` and adding it to `neurosynth.analysis.meta.analyze_features` instead.